### PR TITLE
Use new Blackfire GPG key and https for packages download

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Available variables are listed below, along with default values (see `defaults/m
 The Blackfire packages this role will install on the server. Note that `blackfire-php` may not work well with XHProf and/or XDebug.
 
     blackfire_gpg_key_url: https://packagecloud.io/gpg.key
-    blackfire_repo_url: http://packages.blackfire.io/fedora/blackfire.repo
+    blackfire_repo_url: https://packages.blackfire.io/fedora/blackfire.repo
 
 Variables used for Blackfire package setup and installation.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@ blackfire_packages:
   - blackfire-php
 
 blackfire_gpg_key_url: https://packagecloud.io/gpg.key
-blackfire_repo_url: http://packages.blackfire.io/fedora/blackfire.repo
+blackfire_repo_url: https://packages.blackfire.io/fedora/blackfire.repo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,5 @@ blackfire_packages:
   - blackfire-agent
   - blackfire-php
 
-blackfire_gpg_key_url: https://packagecloud.io/gpg.key
+blackfire_gpg_key_url: https://packages.blackfire.io/gpg.key
 blackfire_repo_url: https://packages.blackfire.io/fedora/blackfire.repo

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,7 +10,7 @@
     state: present
   register: packagecloud_repos
   with_items:
-    - "deb http://packages.blackfire.io/debian any main"
+    - "deb https://packages.blackfire.io/debian any main"
 
 - name: Update apt caches after repo is added.
   apt: update_cache=yes

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,5 +13,6 @@
     - "deb https://packages.blackfire.io/debian any main"
 
 - name: Update apt caches after repo is added.
-  apt: update_cache=yes
+  apt:
+    update_cache: true
   when: packagecloud_repos.changed

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,7 +1,7 @@
 ---
-- name: Add packagecloud GPG key.
-  rpm_key:
-    key: "{{ blackfire_gpg_key_url }}"
+- name: Install pygpgme.
+  yum:
+    name: pygpgme
     state: present
 
 - name: Check if Blackfire repository file exists.
@@ -15,10 +15,3 @@
     dest: /etc/yum.repos.d/blackfire.repo
     mode: 0644
   when: not repo_file_stat.stat.exists
-
-- name: Disable gpg_repocheck for non-bleeding-edge CentOS.
-  lineinfile:
-    dest: /etc/yum.repos.d/blackfire.repo
-    regexp: "^repo_gpgcheck="
-    line: "repo_gpgcheck=0"
-    state: present

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,7 +5,8 @@
     state: present
 
 - name: Check if Blackfire repository file exists.
-  stat: path=/etc/yum.repos.d/blackfire.repo
+  stat:
+    path: /etc/yum.repos.d/blackfire.repo
   register: repo_file_stat
 
 - name: Add Blackfire repository.


### PR DESCRIPTION
The role fails to run on latest Debian due to http:// usage, this PR uses https to fix this.